### PR TITLE
Remove zotonic version

### DIFF
--- a/controllers/controller_github_redirect.erl
+++ b/controllers/controller_github_redirect.erl
@@ -227,7 +227,7 @@ fetch_user_emails(AccessToken) ->
 
 http_headers() ->
     [
-        {"User-Agent", "Zotonic "++?ZOTONIC_VERSION}
+        {"User-Agent", "Zotonic"}
     ].
 
 % {


### PR DESCRIPTION
In 0.x (and master) we removed the `zotonic_version.hrl` include from `zotonic.hrl`.

This means that the `?ZOTONIC_VERSION` macro is not available anymore for modules that only include `zotonic.hrl`.

As we try to have fewer places where we show the exact version number (some customers object to show the version number due to security reasons), I have removed it from this module.